### PR TITLE
Use TRAVIS_BRANCH only in non pull requests

### DIFF
--- a/tasks/branch_run.js
+++ b/tasks/branch_run.js
@@ -47,7 +47,7 @@ module.exports = function(grunt) {
       }
           
       //for travis-ci
-      if(process.env.TRAVIS_BRANCH){
+      if(process.env.TRAVIS_BRANCH && process.env.TRAVIS_PULL_REQUEST == "false"){
         branch = process.env.TRAVIS_BRANCH;
       }
       


### PR DESCRIPTION
If `TRAVIS_PULL_REQUEST` is true, `TRAVIS_BRANCH` will always be master.
